### PR TITLE
Fix /changetimings crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -1057,7 +1057,11 @@ async def changetimings(message: discord.Interaction,
         try:
             del db["spawn_times"][message.channel.id]
         except:
-            del db["spawn_times"][str(message.channel.id)] # IDK WHY BLAME JSON
+            try:
+                del db["spawn_times"][str(message.channel.id)] # IDK WHY BLAME JSON
+            except:
+                await message.response.send_message("This channel already has default spawning intervals.")
+                return
         save("spawn_times")
         await message.response.send_message("Success! This channel is now reset back to usual spawning intervals.")
     elif minimum_time and maximum_time:


### PR DESCRIPTION
fix a crash when doing /changetimings with no arguments and already having default spawning intervals.
this has existed for a while now i think
also i hope this doesn't break anything