### PR TITLE
Add randomization to /Fake

### DIFF
--- a/main.py
+++ b/main.py
@@ -888,11 +888,11 @@ async def postpone_reminder(interaction):
 
 # a loop for various maintaince which is ran every 5 minutes
 async def maintaince_loop():
-    global pointlaugh_ratelimit, reactions_ratelimit, last_loop_time, loop_count, catchcooldown, cooldown, temp_belated_storage, temp_cookie_storage
+    global pointlaugh_ratelimit, reactions_ratelimit, last_loop_time, loop_count, catchcooldown, fakecooldown, temp_belated_storage, temp_cookie_storage
     pointlaugh_ratelimit = {}
     reactions_ratelimit = {}
     catchcooldown = {}
-    cooldown = {}
+    fakecooldown = {}
     await bot.change_presence(activity=discord.CustomActivity(name=f"Catting in {len(bot.guilds):,} servers"))
 
     # update cookies


### PR DESCRIPTION
Added a randomizer to the /fake command as it was getting hard to prank my friends in the discord. This basically just selects a cat from the list, grabs the photo, and does all the same things you had it doing before. This unfortunately removes the Australian cat from use.

I added this in the comments above my changes, but do note that this is not fully tested. I ran a few test cases based on a basic replication of your setup, but no actual proper full bot run.

This is my first PR here and i apologize in advance if this is a feature youve previously rejected or simply don't want. I feel it would be fun to add, perhaps with a toggle for admins on if they want the fake command to be hard mode yk