### PR TITLE
fix typo

### DIFF
--- a/config/aches.json
+++ b/config/aches.json
@@ -51,7 +51,7 @@
   "pig50": {"title": "Pig Expert", "description": "finish with 50+ score in /pig", "is_hidden": false, "category": "Random"},
   "failed_gambler": {"title": "Failed Gambler", "description": "get to negatives in /roulette", "is_hidden": false, "category": "Random"},
   "rugpulled": {"title": "Rugpulled", "description": "get a negative stocks reward", "is_hidden": true, "category": "Random"},
-  "baker": {"title": "Pro Baker", "description": "deliver a /bakey order", "is_hidden": false, "category": "Random"},
+  "baker": {"title": "Pro Baker", "description": "deliver a /bakery order", "is_hidden": false, "category": "Random"},
 
   "silly": {"title": "Silly", "description": "triple-react!", "is_hidden": false, "category": "Silly"},
   "nice": {"title": "Nice!", "description": "gift 69 nice cats", "is_hidden": false, "category": "Silly"},


### PR DESCRIPTION
bakey -> bakery
this cannot be called canon as it is factually incorrect (there's no /bakey command)

_coderabbit if you show up on my pr i swear i will disassemble your AI datacenters_