### PR TITLE
add auto_delete_catches option in guild settings

### DIFF
--- a/main.py
+++ b/main.py
@@ -2475,7 +2475,9 @@ async def on_message(message: discord.Message):
                         )
 
                         if server.auto_delete_catches:
-                            await result.delete(delay=10)
+                            # button do stuff = button stay... for now-
+                            delay = delay = 30 if (button and button.callback) else 10
+                            await result.delete(delay=delay)
 
                     except Exception:
                         # Silently fail if we can't send the confirmation message (e.g. permission issues)
@@ -3670,7 +3672,7 @@ async def settings(message: discord.Interaction):
                 ),
                 Section(
                     "### Auto-Delete Catches",
-                    'If enabled, will delete all "user cought" messages after 10 seconds',
+                    'If enabled, will delete all "user cought" messages after ~10 seconds',
                     make_button("auto_delete_catches"),
                 ),
                 "===",

--- a/main.py
+++ b/main.py
@@ -2464,7 +2464,7 @@ async def on_message(message: discord.Message):
                         if view:
                             kwargs["view"] = view
 
-                        await send_target.send(
+                        result = await send_target.send(
                             coughstring.replace("{username}", message.author.name.replace("_", "\\_"))
                             .replace("{emoji}", str(icon))
                             .replace("{type}", le_emoji)
@@ -2473,6 +2473,10 @@ async def on_message(message: discord.Message):
                             + suffix_string,
                             **kwargs,
                         )
+
+                        if server.auto_delete_catches:
+                            await result.delete(delay=10)
+
                     except Exception:
                         # Silently fail if we can't send the confirmation message (e.g. permission issues)
                         pass
@@ -3663,6 +3667,11 @@ async def settings(message: discord.Interaction):
                     "### Auto-Delete Achievements",
                     'If enabled, will delete all "achievement get" messages after 10 seconds',
                     make_button("auto_delete_achievements"),
+                ),
+                Section(
+                    "### Auto-Delete Catches",
+                    'If enabled, will delete all "user cought" messages after 10 seconds',
+                    make_button("auto_delete_catches"),
                 ),
                 "===",
                 Section("### Cat Rains", "Controls whether Cat Rains can happen", make_button("do_rain")),

--- a/main.py
+++ b/main.py
@@ -2476,7 +2476,7 @@ async def on_message(message: discord.Message):
 
                         if server.auto_delete_catches:
                             # button do stuff = button stay... for now-
-                            delay = delay = 30 if (button and button.callback) else 10
+                            delay = 30 if (button and button.callback) else 10
                             await result.delete(delay=delay)
 
                     except Exception:

--- a/schema.sql
+++ b/schema.sql
@@ -388,6 +388,7 @@ CREATE TABLE public.server (
     do_rain boolean DEFAULT true,
     do_catnip boolean DEFAULT true,
     auto_delete_achievements boolean DEFAULT false,
+    auto_delete_catches boolean DEFAULT false,
     mute_achievements boolean DEFAULT false,
     anti_double_catch boolean DEFAULT false
 );


### PR DESCRIPTION
adds a new guild setting similar to `auto_delete_achievements` but for catch messages.
also adds `auto_delete_catches` column to `schema.sql`

Auto-deletes catch messages after 10s:

[Screencast_20260414_151329.webm](https://github.com/user-attachments/assets/d777b092-fe40-4cc0-ba8d-bd9799ca145a)
