### PR TITLE
allow configuring database host

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,7 +4,8 @@ import os
 TOKEN = os.environ["TOKEN"]
 
 # db password for postgres
-# user - cat_bot, database - cat_bot, ip - localhost, port - default
+# user - cat_bot, database - cat_bot, port - default
+DB_HOST = os.environ.get("psql_host", "127.0.0.1")
 DB_PASS = os.environ["psql_password"]
 
 #

--- a/database.py
+++ b/database.py
@@ -19,7 +19,7 @@ import config
 
 
 async def connect():
-    await catpg.connect(user="cat_bot", password=config.DB_PASS, database="cat_bot", host="127.0.0.1", max_size=80)
+    await catpg.connect(user="cat_bot", password=config.DB_PASS, database="cat_bot", host=config.DB_HOST, max_size=80)
 
 
 async def close():


### PR DESCRIPTION
Adds the ability to configure the DB host the bot connects to, defaults to previous behaviour of `127.0.0.1`.
Mainly a convenience PR, aimed at contributors using a dockerised development environment.