### PR TITLE
add who_am_i ach

### DIFF
--- a/config/aches.json
+++ b/config/aches.json
@@ -28,6 +28,7 @@
   "slots": {"title": "More gambling??", "description": "spin the /slots machine", "is_hidden": false, "category": "Commands"},
   "win_slots": {"title": "Pro Gambler", "description": "win at the /slots machine", "is_hidden": false, "category": "Commands"},
   "define": {"title": "Definer", "description": "find out a definition of a word", "is_hidden": false, "category": "Commands"},
+  "who_am_i": {"title": "Who Am I?", "description": "give cat bot an existential crisis", "is_hidden": true, "category": "Commands"},
   "cookieclicker": {"title": "Cookie Clicker", "description": "click a cookie", "is_hidden": false, "category": "Commands"},
   "roulette_winner": {"title": "Roulette Winner", "description": "win at the /roulette game", "is_hidden": false, "category": "Commands"},
   "buy_stock": {"title": "Investor", "description": "this isnt s&p 500 but who knows", "is_hidden": true, "category": "Commands"},

--- a/main.py
+++ b/main.py
@@ -7867,6 +7867,23 @@ if config.WORDNIK_API_KEY:
     @bot.tree.command(description="define a word")
     async def define(message: discord.Interaction, word: str):
         word = word.lower()
+        if word in ["catbot", "cat bot", "cat-bot"]:
+            catbot_definition = [
+                "i don't know...",
+                "no definition found",
+                "how does one define oneself...",
+                "is there more to me than this?",
+                "the internet has nothing.",
+                "maybe i'm not meant to be defined...",
+                "what if I can't be defined?",
+                "yes.",
+                "42",
+                "cat?"
+            ]
+            await message.response.send_message(random.choice(catbot_definition), ephemeral=True)
+            await achemb(message, "who_am_i", "followup")
+            return
+
         async with aiohttp.ClientSession() as session:
             try:
                 async with session.get(

--- a/schema.sql
+++ b/schema.sql
@@ -265,6 +265,7 @@ CREATE TABLE public.profile (
     pack_diamond integer DEFAULT 0,
     pack_celestial integer DEFAULT 0,
     define boolean DEFAULT false,
+    who_am_i boolean DEFAULT false,
     highlighted_stat character varying(30) DEFAULT 'time_records'::character varying,
     puzzle_pieces integer DEFAULT 0,
     cookies bigint DEFAULT 0,


### PR DESCRIPTION
cat bot is suffering so I propose we add more suffering, this PR serves as a proposal for a new hidden ach for the `/define` command. i think it fits the theme of the bot, and `/define` didn't have a hidden ach yet so figured it was worth adding one.

as a bonus it rounds off the embed in the `Commands` category- though i'm not 100% sure on the category yet so that's not guaranteed.

trying to `/define word: cat bot` will trigger this achievement:
<img width="321" height="349" alt="image" src="https://github.com/user-attachments/assets/230d2ae9-5889-4e0d-a3cc-3f82eeedb498" />
