### PR TITLE
add chaos and chatgpt bp quests

### DIFF
--- a/config/battlepass.json
+++ b/config/battlepass.json
@@ -621,7 +621,9 @@
       "wiki": {"emoji": "🤓", "title": "Check out /wiki", "xp_min": 120, "xp_max": 200, "progress": 1},
       "pig": {"emoji": "🎲", "title": "Get 20+ score in /pig", "xp_min": 200, "xp_max": 250, "progress": 1},
       "roulette": {"emoji": "🎰", "title": "Win a /roulette bet", "xp_min": 175, "xp_max": 225, "progress": 1},
-      "plush": {"emoji": "📦", "title": "Run /plush", "xp_min": 180, "xp_max": 250, "progress": 1}
+      "plush": {"emoji": "📦", "title": "Run /plush", "xp_min": 180, "xp_max": 250, "progress": 1},
+      "chaos": {"emoji": "💥", "title": "Contribute to the /chaos", "xp_min": 140, "xp_max": 220, "progress": 1},
+      "catgpt": {"emoji": "ℹ️", "title": "Send a query to /catgpt", "xp_min": 120, "xp_max": 200, "progress": 1}
     }
   }
 }

--- a/main.py
+++ b/main.py
@@ -6859,8 +6859,11 @@ async def chaos(message: discord.Interaction):
         else:
             await interaction.response.defer()
             await interaction.edit_original_response(view=view)
+        
 
     await click(message, True)
+    user = await Profile.get_or_create(guild_id=message.guild.id, user_id=message.user.id)
+    await progress(message, user, "chaos")
 
 
 @bot.tree.command(description="roll a dice")
@@ -7041,6 +7044,8 @@ async def catgpt(message: discord.Interaction, query: str):
     await asyncio.sleep(6)
     await message.followup.send("cat\n-# 🛈 CatGPT can't make mistakes.")
     await achemb(message, "catgpt", "followup")
+    user = await Profile.get_or_create(guild_id=message.guild.id, user_id=message.user.id)
+    await progress(message, user, "catgpt")
 
 
 @bot.tree.command(description="the most engaging boring game")


### PR DESCRIPTION
This PR adds cattlepass quests for the new `/chaos` and `/catgpt` commands. I tried to make the XP values similar to the existing quests. However, I am, of course, open to tweaks before a final decision on whether to merge this is made.