### PR TITLE
align double xp informer with actual double xp time

### DIFF
--- a/main.py
+++ b/main.py
@@ -5237,7 +5237,7 @@ async def battlepass(message: discord.Interaction):
             description += f"✅ ~~Vote on Top.gg~~\n- Refreshes <t:{int(user.vote_cooldown + 12 * 3600)}:R>{streak_string}\n"
         else:
             # inform double vote xp during weekends
-            is_weekend = now.weekday() >= 4
+            is_weekend = (now - datetime.timedelta(hours=4)).weekday() >= 4
 
             if is_weekend:
                 description += "-# *Double Vote XP During Weekends*\n"


### PR DESCRIPTION
current double xp informer is 4 hours off from when double xp is actually given