### PR TITLE
Fix typo in te reo Māori translation: negeru → ngeru

### DIFF
--- a/main.py
+++ b/main.py
@@ -569,7 +569,7 @@ cat_translations = [
     "wesa",
     "popoki",
     "piqtuq",
-    "negeru",
+    "ngeru",
     "poti",
     "mosi",
     "michi",


### PR DESCRIPTION
I actually opened up the repo to add 'ngeru' and then I realised that considering 'negeru' is listed next to 'poti', another te reo Māori word for cat, it must be meant to be 'ngeru'. If that is indeed meant to be te reo Māori, negeru is not a valid word, there is no letter 'g' (just a letter 'ng') in modern te reo Māori. Ngeru means cat in te reo Māori :)