### PR TITLE
fixed typo: "cattypes" into "cat types"

### DIFF
--- a/config/battlepass.json
+++ b/config/battlepass.json
@@ -700,7 +700,7 @@
       "catch": {"emoji": "nicecat", "title": "Catch 70 cats", "progress": 70, "start_time": 0, "end_time": 604800},
       "brave+": {"emoji": "bravecat", "title": "Catch 5 cats rarer than Brave", "progress": 5, "start_time": 604800, "end_time": 1209600},
       "bonus": {"emoji": "🎁", "title": "Complete 4 bonus minigames", "progress": 4, "start_time": 1209600, "end_time": 1814400},
-      "different": {"emoji": "wildcat", "title": "Catch 13 different cattypes", "progress": 13, "start_time": 1814400, "end_time": 2419200},
+      "different": {"emoji": "wildcat", "title": "Catch 13 different cat types", "progress": 13, "start_time": 1814400, "end_time": 2419200},
       "": {"emoji": "", "title": "", "progress": 0, "start_time": 2419200, "end_time": 300000}
     }
   }


### PR DESCRIPTION
i noticed there was a typo with the "different" weekly quest, and wanted to fix it, so i did. "Catch 13 different cattypes" is now "Catch 13 different cat types".