### PR TITLE
Add a colon to answer_clean for minigames

### DIFF
--- a/main.py
+++ b/main.py
@@ -1877,7 +1877,7 @@ async def play_minigame(interaction: discord.Interaction) -> None:
 
         assert answer_raw is not None
 
-        answer_clean = " ".join(re.sub(r"[^0-9A-Za-z \-~]+", "", answer_raw.replace(",", " ")).split())  # user answer
+        answer_clean = " ".join(re.sub(r"[^0-9A-Za-z \-~:]+", "", answer_raw.replace(",", " ")).split())  # user answer
         answer = " ".join(re.sub(r"[^0-9A-Za-z \-~]+", "", str(answer).replace(",", " ")).split())  # correct answer
 
         match cattype:


### PR DESCRIPTION
Add a colon (':') to the answer_clean variable so that ':3' can actually be used for eGirl minigame