### PR TITLE
Fix theming for aura-suffixed emoji names

### DIFF
--- a/main.py
+++ b/main.py
@@ -317,7 +317,15 @@ server_count = 0
 
 
 def get_emoji(name: str) -> str:
-    if config.EMOJI and name in allowedemojis:
+    # aura-suffixed names (e.g. "finecat_r") aren't in allowedemojis themselves, so check
+    # the base name they're built from to let themed prefixes apply to aura variants too
+    themeable_name = name
+    for suffix in ("_r", "_p", "_c", "_y", "_a"):
+        if name.endswith(suffix) and name[: -len(suffix)] in allowedemojis:
+            themeable_name = name[: -len(suffix)]
+            break
+
+    if config.EMOJI and themeable_name in allowedemojis:
         themed_name = data.emoji_theme_prefixes[config.EMOJI] + name
         if themed_name in emojis:
             return emojis[themed_name]


### PR DESCRIPTION
## Summary
- `get_emoji()` only applies a theme prefix (`b_`/`p_`/`o_`) when the requested name is in `allowedemojis`, but that list only holds base cat names (e.g. `finecat`), not aura-suffixed variants like `finecat_c`.
- So `get_aura_emoji()` calling `get_emoji("finecat_c")` never got themed regardless of the active spawn theme — aura variants always fell back to the default-theme emoji (or a blank square if that wasn't uploaded), even when birthday/halloween/old aura artwork exists.
- Now checks whether the name minus a known aura suffix (`_r`/`_p`/`_c`/`_y`/`_a`) is an allowed cat emoji before deciding whether to theme it, without touching `allowedemojis` itself (it's also used to parse catch messages and to block cat-emoji-lookalikes in custom text, where adding aura suffixes wouldn't make sense).

## Test plan
- [x] `py_compile` / `pyflakes` clean, no new warnings
- [x] Isolated logic test covering: aura variant themes correctly when a themed asset exists, falls back to the default-theme aura variant when it doesn't, base (non-aura) theming is unaffected (regression check), and no prefix is applied when no theme is active
- [ ] Manual verification in a live bot once aura art for a non-default theme is uploaded (I don't have upload access to the app's emoji list)